### PR TITLE
target specific asg

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -20,6 +20,7 @@ Resources:
       Type: AWS::AutoScaling::LifecycleHook
       Properties:
         AutoScalingGroupName: !Ref AutoScalingGroup
+        HeartbeatTimeout: 300
         LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
 
     DrainerFunction:
@@ -50,9 +51,11 @@ Resources:
                 Pattern:
                   source:
                     - aws.autoscaling
+                  detail-type:
+                    - EC2 Instance-terminate Lifecycle Action
                   detail:
-                    LifecycleTransition:
-                      - autoscaling:EC2_INSTANCE_TERMINATING
+                    AutoScalingGroupName:
+                      - !Ref AutoScalingGroup
 
     Permission:
       Type: AWS::Lambda::Permission


### PR DESCRIPTION
If I've read the docs correctly the lambda might have triggered on any autoscaling event (which would have meant the lmabda would run, and fail, against non-EKS nodes). This a waste of resources so the lambda is now targeted to the ASG by making the CloudWatchEvent rule more specific.