### PR TITLE
export lambda iam role from cfn template

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,8 @@ kubectl apply -R -f k8s_rbac/
 ```
 
 You may now create the mapping to the IAM role created when deploying the Drainer function. 
-You can find this role by checking the CloudFormation stack created by the `sam deploy`
-command above (the role is named `DrainerFunctionRole`). Run the `kubectl edit -n kube-system configmap/aws-auth` 
-command and add the following `yaml`:
+You can find this role by checking the `DrainerRole` output of the CloudFormation stack created by the `sam deploy`
+command above. Run `kubectl edit -n kube-system configmap/aws-auth` and add the following `yaml`:
 
 ```yaml
 mapRoles: | 

--- a/template.yaml
+++ b/template.yaml
@@ -23,6 +23,34 @@ Resources:
         HeartbeatTimeout: 300
         LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
 
+    DrainerRole:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - lambda.amazonaws.com
+              Action:
+                - sts:AssumeRole
+        Path: /
+        Policies:
+          - PolicyName: DrainerPolicies
+            PolicyDocument:
+              Version: 2012-10-17
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - autoscaling:CompleteLifecycleAction
+                    - ec2:DescribeInstances
+                    - eks:DescribeCluster
+                    - sts:GetCallerIdentity
+                  Resource: '*'
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
     DrainerFunction:
         Type: AWS::Serverless::Function
         Properties:
@@ -33,17 +61,7 @@ Resources:
           Environment:
             Variables:
               CLUSTER_NAME: !Ref EksCluster
-          Policies:
-            - AWSLambdaExecute
-            - Version: 2012-10-17
-              Statement:
-                - Effect: Allow
-                  Action:
-                    - autoscaling:CompleteLifecycleAction
-                    - ec2:DescribeInstances
-                    - eks:DescribeCluster
-                    - sts:GetCallerIdentity
-                  Resource: '*'
+          Role: !GetAtt DrainerRole.Arn
           Events:
             TerminationEvent:
               Type: CloudWatchEvent
@@ -66,6 +84,6 @@ Resources:
 
 Outputs:
 
-    DrainerFunction:
-      Description: Draining function Arn
-      Value: !GetAtt DrainerFunction.Arn
+    DrainerRole:
+      Description: Draining function role ARN
+      Value: !GetAtt DrainerRole.Arn


### PR DESCRIPTION
As #4 has show, exporting the function ARN is not only not required it can be potentially confusing. This pull requests creates the role in CFN rather than relying on SAM to create it and exports it as a stack output.
