### PR TITLE
Wait for drain to upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ This sample code provides a means to gracefully terminate nodes of an Amazon Ela
 
 The code provides an AWS Lambda function that integrates as an [Amazon EC2 Auto
 Scaling Lifecycle Hook](https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html).
-When called, the Lambda function calls the Kubernetes API to cordon, and evict all pods, from the node being 
-terminated. The Auto Scaling group continues to terminate the EC2 instance once all pods placed on it are evicted.
+When called, the Lambda function calls the Kubernetes API to cordon and evict all evictable pods from the node being 
+terminated. It will then wait until all pods have been evicted before the Auto Scaling group continues to terminate the
+EC2 instance. The lambda may be killed by the function timeout before all evictions complete successfully, in which case
+the lifecycle hook may re-execute the lambda to try again. If the lifecycle heartbeat expires then termination of the EC2
+instance will continue regardless of whether or not draining was successful. You may need to increase the function and
+heartbeat timeouts in template.yaml if you have very long grace periods.
 
 Using this approach can minimise disruption to the services running in your cluster by allowing Kubernetes to 
 reschedule the pod prior to the instance being terminated enters the TERMINATING state. It works by using 
@@ -212,3 +216,5 @@ By default, built artifacts are written to the `.aws-sam/build` directory.
 
 This solution works on a per cluster per autoscaling group basis, multiple autoscaling groups will require a separate 
 deployment for each group.
+
+Certain types of pod cannot be evicted from a node, so this lambda will not attempt to evict DaemonSets or mirror pods.

--- a/drainer/k8s_utils.py
+++ b/drainer/k8s_utils.py
@@ -7,7 +7,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-
 def cordon_node(api, node_name):
     """Marks the specified node as unschedulable, which means that no new pods can be launched on the
     node by the Kubernetes scheduler.
@@ -28,19 +27,23 @@ def cordon_node(api, node_name):
 
 def remove_all_pods(api, node_name, poll=5):
     """Removes all Kubernetes pods from the specified node."""
-    field_selector = 'spec.nodeName=' + node_name
-    pods = api.list_pod_for_all_namespaces(watch=False, field_selector=field_selector)
+    pods = get_pods_on_node(api, node_name)
 
     logger.debug('Number of pods to delete: ' + str(len(pods.items)))
 
-    try_until_completed(api, evict_pods, pods, poll)
-    try_until_completed(api, get_pending, pods, poll)
+    evict_until_completed(api, pods, poll)
+    wait_until_empty(api, node_name, poll)
 
 
-def try_until_completed(api, action, pods, poll):
+def get_pods_on_node(api, node_name):
+    field_selector = 'spec.nodeName=' + node_name
+    return api.list_pod_for_all_namespaces(watch=False, field_selector=field_selector, include_uninitialized=True)
+
+
+def evict_until_completed(api, pods, poll):
     pending = pods.items
-    while len(pending) > 0:
-        pending = action(api, pending)
+    while True:
+        pending = evict_pods(api, pending)
         if (len(pending)) <= 0:
             return
         time.sleep(poll)
@@ -72,26 +75,15 @@ def evict_pods(api, pods):
     return remaining
 
 
-def get_pending(api, pods):
-    pending = []
-    for old_pod in pods:
-        try:
-            current_pod = api.read_namespaced_pod(old_pod.metadata.name, old_pod.metadata.namespace)
-            if current_pod.metadata.uid == old_pod.metadata.uid:
-                logger.debug("Pod %s in namespace %s is still awaiting deletion", old_pod.metadata.name, old_pod.metadata.namespace)
-                pending.append(old_pod)
-            else:
-                logger.info("Eviction successful: %s in namespace %s", old_pod.metadata.name, old_pod.metadata.namespace)
-        except ApiException as err:
-            if err.status == 404:
-                logger.info("Eviction successful: %s in namespace %s", old_pod.metadata.name, old_pod.metadata.namespace)
-            else:
-                pending.append(old_pod)
-                logger.exception("Unexpected error waiting for pod %s in namespace %s", old_pod.metadata.name, old_pod.metadata.namespace)
-        except:
-            logger.exception("Unexpected error waiting for pod %s in namespace %s", old_pod.metadata.name, old_pod.metadata.namespace)
-            pending.append(old_pod)
-    return pending
+def wait_until_empty(api, node_name, poll):
+    logger.info("Waiting for evictions to complete")
+    while True:
+        pods = get_pods_on_node(api, node_name)
+        if len(pods.items) <= 0:
+            logger.info("All pods evicted successfully")
+            return
+        logger.debug("Still waiting for deletion of the following pods: %s", ", ".join(map(lambda pod: pod.metadata.namespace + "/" + pod.metadata.name, pods.items)))
+        time.sleep(poll)
 
 
 def node_exists(api, node_name):

--- a/drainer/k8s_utils.py
+++ b/drainer/k8s_utils.py
@@ -34,6 +34,7 @@ def remove_all_pods(api, node_name):
         body = {
             'apiVersion': 'policy/v1beta1',
             'kind': 'Eviction',
+            'deleteOptions': {},
             'metadata': {
                 'name': pod.metadata.name,
                 'namespace': pod.metadata.namespace

--- a/template.yaml
+++ b/template.yaml
@@ -12,7 +12,7 @@ Parameters:
 
 Globals:
     Function:
-        Timeout: 30
+        Timeout: 300
 
 Resources:
 
@@ -20,7 +20,7 @@ Resources:
       Type: AWS::AutoScaling::LifecycleHook
       Properties:
         AutoScalingGroupName: !Ref AutoScalingGroup
-        HeartbeatTimeout: 300
+        HeartbeatTimeout: 450
         LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
 
     DrainerRole:

--- a/tests/drainer/test_handler.py
+++ b/tests/drainer/test_handler.py
@@ -50,12 +50,16 @@ def mock_k8s_client(mocker):
         {'metadata': {
             'uid': 'aaa',
             'name': 'test_pod1',
-            'namespace': 'test_ns'
+            'namespace': 'test_ns',
+            'annotations': None,
+            'owner_references': None
         }
         }, {'metadata': {
             'uid': 'bbb',
             'name': 'test_pod2',
-            'namespace': 'test_ns'
+            'namespace': 'test_ns',
+            'annotations': None,
+            'owner_references': None
         }
         }
     ]})

--- a/tests/drainer/test_handler.py
+++ b/tests/drainer/test_handler.py
@@ -48,10 +48,12 @@ def mock_k8s_client_no_nodes(mocker):
 def mock_k8s_client(mocker):
     list_pods_val = dict_to_simple_namespace({'items': [
         {'metadata': {
+            'uid': 'aaa',
             'name': 'test_pod1',
             'namespace': 'test_ns'
         }
         }, {'metadata': {
+            'uid': 'bbb',
             'name': 'test_pod2',
             'namespace': 'test_ns'
         }
@@ -62,7 +64,9 @@ def mock_k8s_client(mocker):
 
     mock_api = mocker.Mock(**{'list_pod_for_all_namespaces.return_value': list_pods_val,
                               'list_node.return_value': list_node_val,
-                              'patch_node.return_value': mocker.Mock()})
+                              'patch_node.return_value': mocker.Mock(),
+                              'read_namespaced_pod.side_effect': ApiException(status=404)}
+                           )
 
     class Configuration:
 

--- a/tests/drainer/test_k8s_utils.py
+++ b/tests/drainer/test_k8s_utils.py
@@ -1,3 +1,6 @@
+from kubernetes.client.rest import ApiException
+from mock import call
+
 from drainer.k8s_utils import (abandon_lifecycle_action, cordon_node, node_exists, remove_all_pods)
 from tests.utils import dict_to_simple_namespace
 
@@ -43,17 +46,21 @@ def test_cordon_node(mocker):
 def test_remove_all_pods(mocker):
     list_pods_val = dict_to_simple_namespace({'items': [
         {'metadata': {
+            'uid': 'aaa',
             'name': 'test_pod1',
             'namespace': 'test_ns'
         }
         }, {'metadata': {
+            'uid': 'bbb',
             'name': 'test_pod2',
             'namespace': 'test_ns'
         }
         }
     ]})
 
-    mock_api = mocker.Mock(**{'list_pod_for_all_namespaces.return_value': list_pods_val})
+    mock_api = mocker.Mock(**{'list_pod_for_all_namespaces.return_value': list_pods_val,
+                              'read_namespaced_pod.side_effect': ApiException(status=404)}
+                           )
 
     remove_all_pods(mock_api, 'test_node')
 
@@ -62,6 +69,7 @@ def test_remove_all_pods(mocker):
     mock_arg = {
         'apiVersion': 'policy/v1beta1',
         'kind': 'Eviction',
+        'deleteOptions': {},
         'metadata': {
             'name': 'test_pod1',
             'namespace': 'test_ns'
@@ -71,6 +79,7 @@ def test_remove_all_pods(mocker):
     mock_arg1 = {
         'apiVersion': 'policy/v1beta1',
         'kind': 'Eviction',
+        'deleteOptions': {},
         'metadata': {
             'name': 'test_pod2',
             'namespace': 'test_ns'
@@ -79,3 +88,75 @@ def test_remove_all_pods(mocker):
 
     mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod1-eviction', 'test_ns', mock_arg)
     mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod2-eviction', 'test_ns', mock_arg1)
+
+
+def test_remove_disruption_failure(mocker):
+    list_pods_val = dict_to_simple_namespace({'items': [
+        {'metadata': {
+            'uid': 'aaa',
+            'name': 'test_pod1',
+            'namespace': 'test_ns'
+        }
+        }
+    ]})
+
+    mock_api = mocker.Mock(**{'list_pod_for_all_namespaces.return_value': list_pods_val,
+                              'create_namespaced_pod_eviction.side_effect': [ApiException(status=429), None],
+                              'read_namespaced_pod.side_effect': ApiException(status=404)}
+                           )
+
+    remove_all_pods(mock_api, 'test_node', poll=1)
+
+    mock_api.list_pod_for_all_namespaces.assert_called_with(watch=False, field_selector='spec.nodeName=test_node')
+
+    mock_arg = {
+        'apiVersion': 'policy/v1beta1',
+        'kind': 'Eviction',
+        'deleteOptions': {},
+        'metadata': {
+            'name': 'test_pod1',
+            'namespace': 'test_ns'
+        }
+    }
+
+    mock_api.create_namespaced_pod_eviction.assert_has_calls([
+        call('test_pod1-eviction', 'test_ns', mock_arg),
+        call('test_pod1-eviction', 'test_ns', mock_arg)]
+    )
+
+def test_remove_pending(mocker):
+    list_pods_val = dict_to_simple_namespace({'items': [
+        {'metadata': {
+            'uid': 'aaa',
+            'name': 'test_pod1',
+            'namespace': 'test_ns'
+        }
+        }
+    ]})
+
+    mock_api = mocker.Mock(**{'list_pod_for_all_namespaces.return_value': list_pods_val,
+                              'read_namespaced_pod.side_effect': [list_pods_val.items[0], ApiException(status=404)]}
+                           )
+
+    remove_all_pods(mock_api, 'test_node', poll=1)
+
+    mock_api.list_pod_for_all_namespaces.assert_called_with(watch=False, field_selector='spec.nodeName=test_node')
+
+    mock_arg = {
+        'apiVersion': 'policy/v1beta1',
+        'kind': 'Eviction',
+        'deleteOptions': {},
+        'metadata': {
+            'name': 'test_pod1',
+            'namespace': 'test_ns'
+        }
+    }
+
+    mock_api.create_namespaced_pod_eviction.assert_any_call('test_pod1-eviction', 'test_ns', mock_arg)
+
+    mock_api.read_namespaced_pod.assert_has_calls([
+        call('test_pod1', 'test_ns'),
+        call('test_pod1', 'test_ns')]
+    )
+
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,14 +3,17 @@ import collections
 from types import SimpleNamespace
 
 
-def dict_to_simple_namespace(orig_dict):
-    def _dict_to_simple_namespace(d):
+def dict_to_simple_namespace(orig_dict, skip={}):
+    def _dict_to_simple_namespace(d, path=""):
         res = {}
         for k, v in d.items():
-            if isinstance(v, list):
-                res[k] = [SimpleNamespace(**_dict_to_simple_namespace(x)) for x in v]
+            cur_path = path + "." + k
+            if skip.get(cur_path):
+                res[k] = v
+            elif isinstance(v, list):
+                res[k] = [SimpleNamespace(**_dict_to_simple_namespace(x, path=cur_path)) for x in v]
             elif isinstance(v, collections.abc.Mapping):
-                res[k] = SimpleNamespace(**_dict_to_simple_namespace(v))
+                res[k] = SimpleNamespace(**_dict_to_simple_namespace(v, path=cur_path))
             else:
                 res[k] = v
         return res


### PR DESCRIPTION
*Description of changes:

This change implements the same logic as found in the kubectl drain command.

It waits until the pods have been deleted before reporting success, delaying
termination of the node until evictions have had a chance to finish.
It also handles cases such as a pod disruption budget preventing eviction.

This change makes the assumption that it's OK to just keep waiting until everything's successfully evicted, or we get killed by the lambda timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
